### PR TITLE
do not build for esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "scripts": {
-        "build:cjs": "tsc --declaration",
-        "build:esm": "tsc --module ESNext && mv ./dist/index.js ./dist/index.mjs",
         "prebuild": "npm run clean",
-        "build": "npm run build:esm && npm run build:cjs",
+        "build": "tsc --declaration",
         "postbuild": "du -h ./dist/*",
         "clean": "rm -rf ./dist",
         "test": "echo \"TODO: test for compatibility with cosmiconfig\" && exit 1",


### PR DESCRIPTION
The build is rather excessive. The tool is meant to be used server side and the change from commonjs to esm doesn't seem to be in any close future, so removing this for now.