### PR TITLE
docs: fix broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ lilconfigSync(
 
 ## Difference to `cosmiconfig`
 Lilconfig does not intend to be 100% compatible with `cosmiconfig` but tries to mimic it where possible. The key differences are:
-- **no** support for yaml files out of the box(`lilconfig` attempts to parse files with no extension as JSON instead of YAML). You can still add the support for YAML files by providing a loader, see an [example](#loaders-example) below.
+- **no** support for yaml files out of the box(`lilconfig` attempts to parse files with no extension as JSON instead of YAML). You can still add the support for YAML files by providing a loader, see an [example](#yaml-loader) below.
 - **no** cache
 
 ### Options difference between the two.


### PR DESCRIPTION
Follow-up of https://github.com/antonk52/lilconfig/commit/e77bd55e17aaa45f763a306469356e782d27f750