### PR TITLE
Support dot config search places

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@types/node": "^14.18.36",
                 "@typescript-eslint/eslint-plugin": "^5.54.0",
                 "@typescript-eslint/parser": "^5.54.0",
-                "cosmiconfig": "^7.0.1",
+                "cosmiconfig": "^7.1.0",
                 "eslint": "^8.35.0",
                 "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-prettier": "^4.2.1",
@@ -2330,9 +2330,9 @@
             "dev": true
         },
         "node_modules/cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
@@ -8749,9 +8749,9 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@types/node": "^14.18.36",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
-        "cosmiconfig": "^7.0.1",
+        "cosmiconfig": "^7.1.0",
         "eslint": "^8.35.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,12 @@ function getDefaultSearchPlaces(name: string): string[] {
         'package.json',
         `.${name}rc.json`,
         `.${name}rc.js`,
-        `${name}.config.js`,
         `.${name}rc.cjs`,
+        `.config/${name}rc`,
+        `.config/${name}rc.json`,
+        `.config/${name}rc.js`,
+        `.config/${name}rc.cjs`,
+        `${name}.config.js`,
         `${name}.config.cjs`,
     ];
 }
@@ -141,7 +145,7 @@ function getPackageProp(
 
 type SearchItem = {
     filepath: string;
-    fileName: string;
+    searchPlace: string;
     loaderKey: string;
 };
 
@@ -150,11 +154,11 @@ function getSearchItems(
     searchPaths: string[],
 ): SearchItem[] {
     return searchPaths.reduce<SearchItem[]>((acc, searchPath) => {
-        searchPlaces.forEach(fileName =>
+        searchPlaces.forEach(sp =>
             acc.push({
-                fileName,
-                filepath: path.join(searchPath, fileName),
-                loaderKey: path.extname(fileName) || 'noExt',
+                searchPlace: sp,
+                filepath: path.join(searchPath, sp),
+                loaderKey: path.extname(sp) || 'noExt',
             }),
         );
 
@@ -200,7 +204,7 @@ export function lilconfig(
             };
 
             const searchItems = getSearchItems(searchPlaces, searchPaths);
-            for (const {fileName, filepath, loaderKey} of searchItems) {
+            for (const {searchPlace, filepath, loaderKey} of searchItems) {
                 try {
                     await fs.promises.access(filepath);
                 } catch {
@@ -210,7 +214,7 @@ export function lilconfig(
                 const loader = loaders[loaderKey];
 
                 // handle package.json
-                if (fileName === 'package.json') {
+                if (searchPlace === 'package.json') {
                     const pkg = await loader(filepath, content);
                     const maybeConfig = getPackageProp(packageProp, pkg);
                     if (maybeConfig != null) {
@@ -312,7 +316,7 @@ export function lilconfigSync(
             };
 
             const searchItems = getSearchItems(searchPlaces, searchPaths);
-            for (const {fileName, filepath, loaderKey} of searchItems) {
+            for (const {searchPlace, filepath, loaderKey} of searchItems) {
                 try {
                     fs.accessSync(filepath);
                 } catch {
@@ -322,7 +326,7 @@ export function lilconfigSync(
                 const content = String(fs.readFileSync(filepath));
 
                 // handle package.json
-                if (fileName === 'package.json') {
+                if (searchPlace === 'package.json') {
                     const pkg = loader(filepath, content);
                     const maybeConfig = getPackageProp(packageProp, pkg);
                     if (maybeConfig != null) {

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -569,13 +569,17 @@ describe('lilconfigSync', () => {
                 const options = {stopDir: '/'};
                 const result = lilconfigSync('non-existent', options).search();
                 expect(
-                    (fs.accessSync as jest.Mock).mock.calls.slice(-6),
+                    (fs.accessSync as jest.Mock).mock.calls.slice(-10),
                 ).toEqual([
                     ['/package.json'],
                     ['/.non-existentrc.json'],
                     ['/.non-existentrc.js'],
-                    ['/non-existent.config.js'],
                     ['/.non-existentrc.cjs'],
+                    ['/.config/non-existentrc'],
+                    ['/.config/non-existentrc.json'],
+                    ['/.config/non-existentrc.js'],
+                    ['/.config/non-existentrc.cjs'],
+                    ['/non-existent.config.js'],
                     ['/non-existent.config.cjs'],
                 ]);
                 const ccResult = cosmiconfigSync(
@@ -969,13 +973,17 @@ describe('lilconfig', () => {
                     options,
                 ).search();
                 expect(
-                    (fs.promises.access as jest.Mock).mock.calls.slice(-6),
+                    (fs.promises.access as jest.Mock).mock.calls.slice(-10),
                 ).toEqual([
                     ['/package.json'],
                     ['/.non-existentrc.json'],
                     ['/.non-existentrc.js'],
-                    ['/non-existent.config.js'],
                     ['/.non-existentrc.cjs'],
+                    ['/.config/non-existentrc'],
+                    ['/.config/non-existentrc.json'],
+                    ['/.config/non-existentrc.js'],
+                    ['/.config/non-existentrc.cjs'],
+                    ['/non-existent.config.js'],
                     ['/non-existent.config.cjs'],
                 ]);
                 const ccResult = await cosmiconfig(

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -564,6 +564,18 @@ describe('lilconfigSync', () => {
             expect(ccResult).toEqual(expected);
         });
 
+        it('checks in hidden .config dir', () => {
+            const searchFrom = path.join(dirname, 'a', 'b', 'c');
+
+            const result = lilconfigSync('hidden').search(searchFrom);
+            const ccResult = cosmiconfigSync('hidden').search(searchFrom);
+
+            const expected = {hidden: true};
+
+            expect(result?.config).toEqual(expected);
+            expect(ccResult?.config).toEqual(expected);
+        });
+
         if (process.platform !== 'win32') {
             it('default for searchFrom till root directory', () => {
                 const options = {stopDir: '/'};
@@ -963,6 +975,18 @@ describe('lilconfig', () => {
 
             expect(result).toEqual(expected);
             expect(ccResult).toEqual(expected);
+        });
+
+        it('checks in hidden .config dir', async () => {
+            const searchFrom = path.join(dirname, 'a', 'b', 'c');
+
+            const result = await lilconfig('hidden').search(searchFrom);
+            const ccResult = await cosmiconfig('hidden').search(searchFrom);
+
+            const expected = {hidden: true};
+
+            expect(result?.config).toEqual(expected);
+            expect(ccResult?.config).toEqual(expected);
         });
 
         if (process.platform !== 'win32') {

--- a/src/spec/search/.config/hiddenrc.json
+++ b/src/spec/search/.config/hiddenrc.json
@@ -1,0 +1,3 @@
+{
+    "hidden": true
+}


### PR DESCRIPTION
- add new search places to default ones
- add tests
- update `fileName` to `searchPlace` as it is no longer a filename, but a path(example `.config/foorc`)
- update order of search places to reflect cosmiconfig