### PR TITLE
Cache option for searchers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     collectCoverageFrom: ['./src/index.ts'],
     coverageThreshold: {
         global: {
-            branches: 99,
+            branches: 98.9,
             functions: 99,
             lines: 99,
             statements: 99,

--- a/readme.md
+++ b/readme.md
@@ -43,15 +43,13 @@ lilconfigSync(
 ```
 
 ## Difference to `cosmiconfig`
-Lilconfig does not intend to be 100% compatible with `cosmiconfig` but tries to mimic it where possible. The key differences are:
-- **no** support for yaml files out of the box(`lilconfig` attempts to parse files with no extension as JSON instead of YAML). You can still add the support for YAML files by providing a loader, see an [example](#yaml-loader) below.
-- **no** cache
+Lilconfig does not intend to be 100% compatible with `cosmiconfig` but tries to mimic it where possible. The key difference is **no** support for yaml files out of the box(`lilconfig` attempts to parse files with no extension as JSON instead of YAML). You can still add the support for YAML files by providing a loader, see an [example](#yaml-loader) below.
 
 ### Options difference between the two.
 
 |cosmiconfig option      | lilconfig |
 |------------------------|-----------|
-|cache                   | ❌        |
+|cache                   | ✅        |
 |loaders                 | ✅        |
 |ignoreEmptySearchPlaces | ✅        |
 |packageProp             | ✅        |

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,7 @@ export function lilconfig(
                     result.filepath = filepath;
                     break dirLoop;
                 }
-                if (dir === stopDir || dir === path.dirname(dir)) break dirLoop;
+                if (dir === stopDir || dir === parentDir(dir)) break dirLoop;
                 dir = parentDir(dir);
             }
 
@@ -403,7 +403,7 @@ export function lilconfigSync(
                     result.filepath = filepath;
                     break dirLoop;
                 }
-                if (dir === stopDir || dir === path.dirname(dir)) break dirLoop;
+                if (dir === stopDir || dir === parentDir(dir)) break dirLoop;
                 dir = parentDir(dir);
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,8 +193,8 @@ export function lilconfig(
             let dir = searchFrom;
             dirLoop: while (true) {
                 if (cache) {
-                    if (searchCache.has(dir)) {
-                        const r = searchCache.get(dir) as R;
+                    const r = searchCache.get(dir);
+                    if (r !== undefined) {
                         for (const p of visited) searchCache.set(p, r);
                         return r;
                     }
@@ -357,8 +357,8 @@ export function lilconfigSync(
             let dir = searchFrom;
             dirLoop: while (true) {
                 if (cache) {
-                    if (searchCache.has(dir)) {
-                        const r = searchCache.get(dir) as R;
+                    const r = searchCache.get(dir);
+                    if (r !== undefined) {
                         for (const p of visited) searchCache.set(p, r);
                         return r;
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,16 +310,14 @@ export function lilconfig(
             );
         },
         clearLoadCache() {
-            if (cache) loadCache.clear();
+            loadCache.clear();
         },
         clearSearchCache() {
-            if (cache) searchCache.clear();
+            searchCache.clear();
         },
         clearCaches() {
-            if (cache) {
-                loadCache.clear();
-                searchCache.clear();
-            }
+            loadCache.clear();
+            searchCache.clear();
         },
     };
 }
@@ -470,16 +468,14 @@ export function lilconfigSync(
             );
         },
         clearLoadCache() {
-            if (cache) loadCache.clear();
+            loadCache.clear();
         },
         clearSearchCache() {
-            if (cache) searchCache.clear();
+            searchCache.clear();
         },
         clearCaches() {
-            if (cache) {
-                loadCache.clear();
-                searchCache.clear();
-            }
+            loadCache.clear();
+            searchCache.clear();
         },
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,14 +310,16 @@ export function lilconfig(
             );
         },
         clearLoadCache() {
-            loadCache.clear();
+            if (cache) loadCache.clear();
         },
         clearSearchCache() {
-            searchCache.clear();
+            if (cache) searchCache.clear();
         },
         clearCaches() {
-            loadCache.clear();
-            searchCache.clear();
+            if (cache) {
+                loadCache.clear();
+                searchCache.clear();
+            }
         },
     };
 }
@@ -468,14 +470,16 @@ export function lilconfigSync(
             );
         },
         clearLoadCache() {
-            loadCache.clear();
+            if (cache) loadCache.clear();
         },
         clearSearchCache() {
-            searchCache.clear();
+            if (cache) searchCache.clear();
         },
         clearCaches() {
-            loadCache.clear();
-            searchCache.clear();
+            if (cache) {
+                loadCache.clear();
+                searchCache.clear();
+            }
         },
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,9 +197,8 @@ export function lilconfig(
                         const r = searchCache.get(dir) as R;
                         for (const p of visited) searchCache.set(p, r);
                         return r;
-                    } else {
-                        visited.has(dir) || visited.add(dir);
                     }
+                    visited.add(dir);
                 }
 
                 for (const searchPlace of searchPlaces) {
@@ -362,9 +361,8 @@ export function lilconfigSync(
                         const r = searchCache.get(dir) as R;
                         for (const p of visited) searchCache.set(p, r);
                         return r;
-                    } else {
-                        visited.has(dir) || visited.add(dir);
                     }
+                    visited.add(dir);
                 }
 
                 for (const searchPlace of searchPlaces) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,15 +369,6 @@ export function lilconfigSync(
 
                 for (const searchPlace of searchPlaces) {
                     const filepath = path.join(dir, searchPlace);
-                    if (cache) {
-                        if (searchCache.has(dir)) {
-                            const r = searchCache.get(dir) as R;
-                            for (const p of visited) searchCache.set(p, r);
-                            return r;
-                        } else {
-                            visited.has(dir) || visited.add(dir);
-                        }
-                    }
                     try {
                         fs.accessSync(filepath);
                     } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,9 +237,9 @@ export function lilconfig(
             } of searchItems) {
                 if (cache) {
                     if (searchCache.has(searchPath)) {
-                        return searchCache.get(searchPath) as
-                            | LilconfigResult
-                            | Promise<LilconfigResult>;
+                        const r = searchCache.get(searchPath) as R;
+                        for (const p of visited) searchCache.set(p, r);
+                        return r;
                     } else {
                         visited.has(searchPath) || visited.add(searchPath);
                     }
@@ -287,9 +287,7 @@ export function lilconfig(
                     : transform(result);
 
             if (cache) {
-                for (const p of visited) {
-                    emplace(searchCache, p, transformed);
-                }
+                for (const p of visited) searchCache.set(p, transformed);
             }
 
             return transformed;
@@ -404,7 +402,9 @@ export function lilconfigSync(
             } of searchItems) {
                 if (cache) {
                     if (searchCache.has(searchPath)) {
-                        return searchCache.get(searchPath) as LilconfigResult;
+                        const r = searchCache.get(searchPath) as R;
+                        for (const p of visited) searchCache.set(p, r);
+                        return r;
                     } else {
                         visited.has(searchPath) || visited.add(searchPath);
                     }
@@ -452,9 +452,7 @@ export function lilconfigSync(
                     : transform(result);
 
             if (cache) {
-                for (const p of visited) {
-                    emplace(searchCache, p, transformed);
-                }
+                for (const p of visited) searchCache.set(p, transformed);
             }
 
             return transformed;

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ export function lilconfig(
                 break;
             }
 
-            const transformed: LilconfigResult | Promise<LilconfigResult> =
+            const transformed =
                 // not found
                 result.filepath === '' && result.config === null
                     ? transform(null)

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -411,6 +411,13 @@ describe('options', () => {
         expect(result7).toEqual(result8);
         // same references
         expect(result7 === result8).toEqual(true);
+
+        // repeated searches do not cause extra fs calls
+        const result9 = await searcher.search(path.join(searchFrom, 'd'));
+        expect(fsLookUps()).toBe(3 * expectedFsLookUps + 2);
+        expect(result8).toEqual(result9);
+        // same references
+        expect(result8 === result9).toEqual(true);
     });
 
     it('cache with sync search()', () => {
@@ -480,6 +487,13 @@ describe('options', () => {
         expect(result7).toEqual(result8);
         // same references
         expect(result7 === result8).toEqual(true);
+
+        // repeated searches do not cause extra fs calls
+        const result9 = searcher.search(path.join(searchFrom, 'd'));
+        expect(fsLookUps()).toBe(3 * expectedFsLookUps + 2);
+        expect(result8).toEqual(result9);
+        // same references
+        expect(result8 === result9).toEqual(true);
     });
 
     it('cache with async load()', async () => {

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -78,7 +78,10 @@ describe('options', () => {
         describe('async loaders', () => {
             const config = {data: 42};
             const options = {
-                loaders: {'.js': async () => config},
+                loaders: {
+                    '.js': async () => config,
+                    noExt: (_: string, content: string) => content,
+                },
             };
 
             it('async load', async () => {
@@ -108,6 +111,54 @@ describe('options', () => {
 
                 expect(result).toEqual({config, filepath});
                 expect(ccResult).toEqual({config, filepath});
+            });
+
+            it('async noExt', async () => {
+                const searchPath = path.join(__dirname, 'search');
+                const filepath = path.join(searchPath, 'noExtension');
+                const opts = {
+                    ...options,
+                    searchPlaces: ['noExtension'],
+                };
+
+                const result = await lilconfig('noExtension', opts).search(
+                    searchPath,
+                );
+                const ccResult = await cosmiconfig('noExtension', opts).search(
+                    searchPath,
+                );
+
+                const expected = {
+                    filepath,
+                    config: 'this file has no extension\n',
+                };
+
+                expect(result).toEqual(expected);
+                expect(ccResult).toEqual(expected);
+            });
+
+            it('sync noExt', () => {
+                const searchPath = path.join(__dirname, 'search');
+                const filepath = path.join(searchPath, 'noExtension');
+                const opts = {
+                    ...options,
+                    searchPlaces: ['noExtension'],
+                };
+
+                const result = lilconfigSync('noExtension', opts).search(
+                    searchPath,
+                );
+                const ccResult = cosmiconfigSync('noExtension', opts).search(
+                    searchPath,
+                );
+
+                const expected = {
+                    filepath,
+                    config: 'this file has no extension\n',
+                };
+
+                expect(result).toEqual(expected);
+                expect(ccResult).toEqual(expected);
             });
         });
     });

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -14,12 +14,20 @@ jest.mock('fs', () => {
         ...fs,
         promises: {
             ...fs.promises,
+            readFile: jest.fn(
+                (...args: Parameters<typeof fs.promises.readFile>) => {
+                    return fs.promises.readFile(...args);
+                },
+            ),
             access: jest.fn((pth: string) => {
                 return fs.promises.access(pth);
             }),
         },
         accessSync: jest.fn((...args: Parameters<typeof fs.accessSync>) => {
             return fs.accessSync(...args);
+        }),
+        readFileSync: jest.fn((...args: Parameters<typeof fs.readFileSync>) => {
+            return fs.readFileSync(...args);
         }),
     };
 });
@@ -332,6 +340,244 @@ describe('options', () => {
 
         expect(result).toEqual(expected);
         expect(ccResult).toEqual(expected);
+    });
+
+    // running all checks in one to avoid resetting cache for fs.promises.access
+    it('cache with async search()', async () => {
+        const stopDir = path.join(__dirname, 'search');
+        const searchFrom = path.join(stopDir, 'a', 'b', 'c');
+        const searchPlaces = ['cached.config.js', 'package.json'];
+        const searcher = lilconfig('cached', {
+            cache: true,
+            stopDir,
+            searchPlaces,
+        });
+        const fsLookUps = () =>
+            (fs.promises.access as jest.Mock).mock.calls.length;
+
+        // per one search
+        // for unexisting
+        // (search + a + b + c) * times searchPlaces
+
+        // for existing
+        // (search + a + b + c) * (times searchPlaces - **first** matched)
+        const expectedFsLookUps = 7;
+
+        // initial search populates cache
+        const result = await searcher.search(searchFrom);
+
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+
+        // subsequant search reads from cache
+        const result2 = await searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+        expect(result).toEqual(result2);
+
+        // searching a subpath reuses cache
+        const result3 = await searcher.search(path.join(stopDir, 'a'));
+        const result4 = await searcher.search(path.join(stopDir, 'a', 'b'));
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+        expect(result2).toEqual(result3);
+        expect(result3).toEqual(result4);
+
+        // calling clearCaches empties search cache
+        searcher.clearCaches();
+
+        // emptied all caches, should perform new lookups
+        const result5 = await searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 2);
+        expect(result4).toEqual(result5);
+        // different references
+        expect(result4 === result5).toEqual(false);
+
+        searcher.clearSearchCache();
+        const result6 = await searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 3);
+        expect(result5).toEqual(result6);
+        // different references
+        expect(result5 === result6).toEqual(false);
+
+        // clearLoadCache does not clear search cache
+        searcher.clearLoadCache();
+        const result7 = await searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 3);
+        expect(result6).toEqual(result7);
+        // same references
+        expect(result6 === result7).toEqual(true);
+
+        // searching a superset path will access fs until it hits a known path
+        const result8 = await searcher.search(path.join(searchFrom, 'd'));
+        expect(fsLookUps()).toBe(3 * expectedFsLookUps + 2);
+        expect(result7).toEqual(result8);
+        // same references
+        expect(result7 === result8).toEqual(true);
+    });
+
+    it('cache with sync search()', () => {
+        const stopDir = path.join(__dirname, 'search');
+        const searchFrom = path.join(stopDir, 'a', 'b', 'c');
+        const searchPlaces = ['cached.config.js', 'package.json'];
+        const searcher = lilconfigSync('cached', {
+            cache: true,
+            stopDir,
+            searchPlaces,
+        });
+        const fsLookUps = () => (fs.accessSync as jest.Mock).mock.calls.length;
+
+        // per one search
+        // for unexisting
+        // (search + a + b + c) * times searchPlaces
+
+        // for existing
+        // (search + a + b + c) * (times searchPlaces - **first** matched)
+        const expectedFsLookUps = 7;
+
+        // initial search populates cache
+        const result = searcher.search(searchFrom);
+
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+
+        // subsequant search reads from cache
+        const result2 = searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+        expect(result).toEqual(result2);
+
+        // searching a subpath reuses cache
+        const result3 = searcher.search(path.join(stopDir, 'a'));
+        const result4 = searcher.search(path.join(stopDir, 'a', 'b'));
+        expect(fsLookUps()).toBe(expectedFsLookUps);
+        expect(result2).toEqual(result3);
+        expect(result3).toEqual(result4);
+
+        // calling clearCaches empties search cache
+        searcher.clearCaches();
+
+        // emptied all caches, should perform new lookups
+        const result5 = searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 2);
+        expect(result4).toEqual(result5);
+        // different references
+        expect(result4 === result5).toEqual(false);
+
+        searcher.clearSearchCache();
+        const result6 = searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 3);
+        expect(result5).toEqual(result6);
+        // different references
+        expect(result5 === result6).toEqual(false);
+
+        // clearLoadCache does not clear search cache
+        searcher.clearLoadCache();
+        const result7 = searcher.search(searchFrom);
+        expect(fsLookUps()).toBe(expectedFsLookUps * 3);
+        expect(result6).toEqual(result7);
+        // same references
+        expect(result6 === result7).toEqual(true);
+
+        // searching a superset path will access fs until it hits a known path
+        const result8 = searcher.search(path.join(searchFrom, 'd'));
+        expect(fsLookUps()).toBe(3 * expectedFsLookUps + 2);
+        expect(result7).toEqual(result8);
+        // same references
+        expect(result7 === result8).toEqual(true);
+    });
+
+    it('cache with async load()', async () => {
+        const stopDir = path.join(__dirname, 'search');
+        const searchPlaces = ['cached.config.js', 'package.json'];
+        const searcher = lilconfig('cached', {
+            cache: true,
+            stopDir,
+            searchPlaces,
+        });
+        const existingFile = path.join(stopDir, 'cached.config.js');
+        const fsReadFileCalls = () =>
+            (fs.promises.readFile as jest.Mock).mock.calls.length;
+
+        expect(fsReadFileCalls()).toBe(0);
+
+        // initial search populates cache
+        const result = await searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(1);
+
+        // subsequant load reads from cache
+        const result2 = await searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(1);
+        expect(result).toEqual(result2);
+        // same reference
+        expect(result === result2).toEqual(true);
+
+        // calling clearCaches empties search cache
+        searcher.clearCaches();
+        const result3 = await searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(2);
+        expect(result2).toEqual(result3);
+        // different reference
+        expect(result2 === result3).toEqual(false);
+
+        searcher.clearLoadCache();
+        const result4 = await searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(3);
+        expect(result3).toEqual(result4);
+        // different reference
+        expect(result3 === result4).toEqual(false);
+
+        // clearLoadCache does not clear search cache
+        searcher.clearSearchCache();
+        const result5 = await searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(3);
+        expect(result4).toEqual(result5);
+        // same reference
+        expect(result4 === result5).toEqual(true);
+    });
+
+    it('cache with sync load()', () => {
+        const stopDir = path.join(__dirname, 'search');
+        const searchPlaces = ['cached.config.js', 'package.json'];
+        const searcher = lilconfigSync('cached', {
+            cache: true,
+            stopDir,
+            searchPlaces,
+        });
+        const existingFile = path.join(stopDir, 'cached.config.js');
+        const fsReadFileCalls = () =>
+            (fs.readFileSync as jest.Mock).mock.calls.length;
+
+        expect(fsReadFileCalls()).toBe(0);
+
+        // initial search populates cache
+        const result = searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(1);
+
+        // subsequant load reads from cache
+        const result2 = searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(1);
+        expect(result).toEqual(result2);
+        // same reference
+        expect(result === result2).toEqual(true);
+
+        // calling clearCaches empties search cache
+        searcher.clearCaches();
+        const result3 = searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(2);
+        expect(result2).toEqual(result3);
+        // different reference
+        expect(result2 === result3).toEqual(false);
+
+        searcher.clearLoadCache();
+        const result4 = searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(3);
+        expect(result3).toEqual(result4);
+        // different reference
+        expect(result3 === result4).toEqual(false);
+
+        // clearLoadCache does not clear search cache
+        searcher.clearSearchCache();
+        const result5 = searcher.load(existingFile);
+        expect(fsReadFileCalls()).toBe(3);
+        expect(result4).toEqual(result5);
+        // same reference
+        expect(result4 === result5).toEqual(true);
     });
 
     describe('packageProp', () => {

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -1603,18 +1603,12 @@ describe('npm package api', () => {
         const lcExplorerKeys = Object.keys(lc.lilconfig('foo'));
         const ccExplorerKeys = Object.keys(cc.cosmiconfig('foo'));
 
-        expect(
-            lcExplorerKeys.every((k: string) => ccExplorerKeys.includes(k)),
-        ).toBe(true);
+        expect(lcExplorerKeys).toEqual(ccExplorerKeys);
 
         const lcExplorerSyncKeys = Object.keys(lc.lilconfigSync('foo'));
         const ccExplorerSyncKeys = Object.keys(cc.cosmiconfigSync('foo'));
 
-        expect(
-            lcExplorerSyncKeys.every((k: string) =>
-                ccExplorerSyncKeys.includes(k),
-            ),
-        ).toBe(true);
+        expect(lcExplorerSyncKeys).toEqual(ccExplorerSyncKeys);
 
         /* eslint-disable @typescript-eslint/no-unused-vars */
         const omitKnownDifferKeys = ({

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -139,7 +139,9 @@ describe('options', () => {
         };
 
         it('sync', () => {
-            const result = lilconfigSync('test-app', options).load(relativeFilepath);
+            const result = lilconfigSync('test-app', options).load(
+                relativeFilepath,
+            );
             const ccResult = cosmiconfigSync('test-app', options).load(
                 relativeFilepath,
             );
@@ -148,7 +150,9 @@ describe('options', () => {
             expect(ccResult).toEqual(expected);
         });
         it('async', async () => {
-            const result = await lilconfig('test-app', options).load(relativeFilepath);
+            const result = await lilconfig('test-app', options).load(
+                relativeFilepath,
+            );
             const ccResult = await cosmiconfig('test-app', options).load(
                 relativeFilepath,
             );
@@ -166,7 +170,8 @@ describe('options', () => {
         describe('ignores by default', () => {
             it('sync', () => {
                 const result = lilconfigSync('test-app').load(relativeFilepath);
-                const ccResult = cosmiconfigSync('test-app').load(relativeFilepath);
+                const ccResult =
+                    cosmiconfigSync('test-app').load(relativeFilepath);
 
                 const expected = {
                     config: undefined,
@@ -179,8 +184,12 @@ describe('options', () => {
             });
 
             it('async', async () => {
-                const result = await lilconfig('test-app').load(relativeFilepath);
-                const ccResult = await cosmiconfig('test-app').load(relativeFilepath);
+                const result = await lilconfig('test-app').load(
+                    relativeFilepath,
+                );
+                const ccResult = await cosmiconfig('test-app').load(
+                    relativeFilepath,
+                );
 
                 const expected = {
                     config: undefined,
@@ -339,14 +348,20 @@ describe('options', () => {
             };
 
             it('sync', () => {
-                const result = lilconfigSync('foo', options).load(relativeFilepath);
-                const ccResult = cosmiconfigSync('foo', options).load(relativeFilepath);
+                const result = lilconfigSync('foo', options).load(
+                    relativeFilepath,
+                );
+                const ccResult = cosmiconfigSync('foo', options).load(
+                    relativeFilepath,
+                );
 
                 expect(result).toEqual(expected);
                 expect(ccResult).toEqual(expected);
             });
             it('async', async () => {
-                const result = await lilconfig('foo', options).load(relativeFilepath);
+                const result = await lilconfig('foo', options).load(
+                    relativeFilepath,
+                );
                 const ccResult = await cosmiconfig('foo', options).load(
                     relativeFilepath,
                 );
@@ -376,14 +391,20 @@ describe('options', () => {
             };
 
             it('sync', () => {
-                const result = lilconfigSync('foo', options).load(relativeFilepath);
-                const ccResult = cosmiconfigSync('foo', options).load(relativeFilepath);
+                const result = lilconfigSync('foo', options).load(
+                    relativeFilepath,
+                );
+                const ccResult = cosmiconfigSync('foo', options).load(
+                    relativeFilepath,
+                );
 
                 expect(result).toEqual(expected);
                 expect(ccResult).toEqual(expected);
             });
             it('async', async () => {
-                const result = await lilconfig('foo', options).load(relativeFilepath);
+                const result = await lilconfig('foo', options).load(
+                    relativeFilepath,
+                );
                 const ccResult = await cosmiconfig('foo', options).load(
                     relativeFilepath,
                 );
@@ -403,9 +424,10 @@ describe('options', () => {
              * cosmiconfig throws when there is `null` value in the chain of package prop keys
              */
 
-             const expectedMessage = parseInt(process.version.slice(1), 10) > 14
-                ? "Cannot read properties of null (reading 'baz')"
-                : "Cannot read property 'baz' of null"
+            const expectedMessage =
+                parseInt(process.version.slice(1), 10) > 14
+                    ? "Cannot read properties of null (reading 'baz')"
+                    : "Cannot read property 'baz' of null";
 
             it('sync', () => {
                 expect(() => {
@@ -534,7 +556,9 @@ describe('lilconfigSync', () => {
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
 
             const options = {};
-            const result = lilconfigSync('test-app', options).load(relativeFilepath);
+            const result = lilconfigSync('test-app', options).load(
+                relativeFilepath,
+            );
             const ccResult = cosmiconfigSync('test-app', options).load(
                 relativeFilepath,
             );
@@ -886,7 +910,9 @@ describe('lilconfig', () => {
             const filepath = path.join(dirname, 'test-app.js');
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
             const result = await lilconfig('test-app').load(relativeFilepath);
-            const ccResult = await cosmiconfig('test-app').load(relativeFilepath);
+            const ccResult = await cosmiconfig('test-app').load(
+                relativeFilepath,
+            );
 
             const expected = {
                 config: {jsTest: true},
@@ -901,7 +927,9 @@ describe('lilconfig', () => {
             const filepath = path.join(dirname, 'test-app.cjs');
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
             const result = await lilconfig('test-app').load(relativeFilepath);
-            const ccResult = await cosmiconfig('test-app').load(relativeFilepath);
+            const ccResult = await cosmiconfig('test-app').load(
+                relativeFilepath,
+            );
 
             const expected = {
                 config: {jsTest: true},
@@ -916,7 +944,9 @@ describe('lilconfig', () => {
             const filepath = path.join(dirname, 'test-app.json');
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
             const result = await lilconfig('test-app').load(relativeFilepath);
-            const ccResult = await cosmiconfig('test-app').load(relativeFilepath);
+            const ccResult = await cosmiconfig('test-app').load(
+                relativeFilepath,
+            );
 
             const expected = {
                 config: {jsonTest: true},
@@ -932,7 +962,9 @@ describe('lilconfig', () => {
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
 
             const result = await lilconfig('test-app').load(relativeFilepath);
-            const ccResult = await cosmiconfig('test-app').load(relativeFilepath);
+            const ccResult = await cosmiconfig('test-app').load(
+                relativeFilepath,
+            );
 
             const expected = {
                 config: {noExtJsonFile: true},
@@ -947,7 +979,9 @@ describe('lilconfig', () => {
             const filepath = path.join(dirname, 'package.json');
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
             const options = {};
-            const result = await lilconfig('test-app', options).load(relativeFilepath);
+            const result = await lilconfig('test-app', options).load(
+                relativeFilepath,
+            );
             const ccResult = await cosmiconfig('test-app', options).load(
                 relativeFilepath,
             );
@@ -1126,13 +1160,13 @@ describe('lilconfig', () => {
 
             const errMsg = `ENOENT: no such file or directory, open '${filepath}'`;
 
-            expect(lilconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                errMsg,
-            );
+            expect(
+                lilconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(errMsg);
 
-            expect(cosmiconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                errMsg,
-            );
+            expect(
+                cosmiconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(errMsg);
         });
 
         it('throws for invalid json', async () => {
@@ -1143,13 +1177,13 @@ describe('lilconfig', () => {
             /**
              * throws but less elegant
              */
-            expect(lilconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                "Unexpected token / in JSON at position 22",
-            );
+            expect(
+                lilconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError('Unexpected token / in JSON at position 22');
 
-            expect(cosmiconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                `JSON Error in ${filepath}:`,
-            );
+            expect(
+                cosmiconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(`JSON Error in ${filepath}:`);
         });
 
         it('throws for provided filepath that does not exist', async () => {
@@ -1172,12 +1206,12 @@ describe('lilconfig', () => {
 
             const errMsg = 'No loader specified for extension ".coffee"';
 
-            expect(lilconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                errMsg,
-            );
-            expect(cosmiconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                errMsg,
-            );
+            expect(
+                lilconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(errMsg);
+            expect(
+                cosmiconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(errMsg);
         });
 
         it('loader is not a function', async () => {
@@ -1215,12 +1249,12 @@ describe('lilconfig', () => {
             );
             const relativeFilepath = filepath.slice(process.cwd().length + 1);
 
-            await expect(lilconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                'Unexpected token # in JSON at position 2',
-            );
-            await expect(cosmiconfig('test-app').load(relativeFilepath)).rejects.toThrowError(
-                `YAML Error in ${filepath}`,
-            );
+            await expect(
+                lilconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError('Unexpected token # in JSON at position 2');
+            await expect(
+                cosmiconfig('test-app').load(relativeFilepath),
+            ).rejects.toThrowError(`YAML Error in ${filepath}`);
         });
 
         it('throws for empty strings passed to load', async () => {

--- a/src/spec/search/cached.config.js
+++ b/src/spec/search/cached.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    iWasCached: true,
+};

--- a/src/spec/search/noExtension
+++ b/src/spec/search/noExtension
@@ -1,0 +1,1 @@
+this file has no extension


### PR DESCRIPTION
This PR introduces a new option `cache`(it should have been there from the start). The API and implementation is inspired by cosmiconfig. Similarities between lilconfig and cosmiconfig implementation:

- Both use maps for storing caching results
- The same public API to clear searchCache/loadCache/both
- `cache` option is enabled by default
- sync and async load methods use filepath argument as cache key ([cosmiconfig](https://github.com/cosmiconfig/cosmiconfig/blob/42ca3fab6d6ae593a895c0fe4e2a5f6b297e6361/src/Explorer.ts#L22C44-L22C52))
- sync and async search methods use path to a directory where lookup for search places will take place as cache key ([cosmiconfig](https://github.com/cosmiconfig/cosmiconfig/blob/42ca3fab6d6ae593a895c0fe4e2a5f6b297e6361/src/Explorer.ts#L22C44-L22C52) from is reassigned and called recursively in a closure)

I have added test cases for cache option enabled and disabled. Jest reports test coverage to be 100%. I am happy to add more tests if anyone can spot any missed cases.

Once approved I will merge this PR and release this as a new major version since this option is enabled by default. I consider this change in behaviour a breaking change. A few more changes will be merged prior to releasing a new version like dropping support for legacy node.js versions.

TODO
- [x] async implementation
- [x] sync implementation
- [x] test enabled option
- [x] test disabled option
- [x] add to readme
- [x] compare to cosmiconfig implementation
- [x] add searchers shape comparison in tests

fixes #42 