### PR TITLE
Drop unsupported nodejs versions (v10 & v12)

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -22,7 +22,6 @@ jobs:
     - name: build
       run: npm run build
     - name: check codestyle
-      if: matrix.node-version != '10.x'
       run: npm run lint
     - name: tests
       run: npm run test

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
         "typescript": "4.4.4"
     },
     "engines": {
-        "node": ">=10"
+        "node": ">=14"
     }
 }

--- a/src/spec/index.spec.ts
+++ b/src/spec/index.spec.ts
@@ -26,6 +26,8 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
+const isNodeV20orNewer = parseInt(process.versions.node, 10) >= 20;
+
 describe('options', () => {
     const dirname = path.join(__dirname, 'load');
 
@@ -1179,7 +1181,11 @@ describe('lilconfigSync', () => {
              */
             expect(() => {
                 lilconfigSync('test-app').load(relativeFilepath);
-            }).toThrowError('Unexpected token / in JSON at position 22');
+            }).toThrowError(
+                isNodeV20orNewer
+                    ? `Expected ',' or '}' after property value in JSON at position 22`
+                    : 'Unexpected token / in JSON at position 22',
+            );
 
             expect(() => {
                 cosmiconfigSync('test-app').load(relativeFilepath);
@@ -1245,7 +1251,11 @@ describe('lilconfigSync', () => {
 
             expect(() => {
                 lilconfigSync('test-app').load(relativeFilepath);
-            }).toThrowError('Unexpected token # in JSON at position 2');
+            }).toThrowError(
+                isNodeV20orNewer
+                    ? `Unexpected non-whitespace character after JSON at position 2`
+                    : 'Unexpected token # in JSON at position 2',
+            );
             expect(() => {
                 cosmiconfigSync('test-app').load(relativeFilepath);
             }).toThrowError(`YAML Error in ${filepath}`);
@@ -1606,7 +1616,11 @@ describe('lilconfig', () => {
              */
             expect(
                 lilconfig('test-app').load(relativeFilepath),
-            ).rejects.toThrowError('Unexpected token / in JSON at position 22');
+            ).rejects.toThrowError(
+                isNodeV20orNewer
+                    ? `Expected ',' or '}' after property value in JSON at position 22`
+                    : 'Unexpected token / in JSON at position 22',
+            );
 
             expect(
                 cosmiconfig('test-app').load(relativeFilepath),
@@ -1678,7 +1692,11 @@ describe('lilconfig', () => {
 
             await expect(
                 lilconfig('test-app').load(relativeFilepath),
-            ).rejects.toThrowError('Unexpected token # in JSON at position 2');
+            ).rejects.toThrowError(
+                isNodeV20orNewer
+                    ? `Unexpected non-whitespace character after JSON at position 2`
+                    : 'Unexpected token # in JSON at position 2',
+            );
             await expect(
                 cosmiconfig('test-app').load(relativeFilepath),
             ).rejects.toThrowError(`YAML Error in ${filepath}`);


### PR DESCRIPTION
Now min required nodejs version is v14.

Currently node.js [LTS versions](https://nodejs.org/en/about/previous-releases) are 18, 20. Soon to be 22.

I expect very few to be using v14 today. As there is no need to use any new API, v14 is a fine minimal target that is also supported by cosmiconfig v8.