### PR TITLE
feat: add startDir option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7086,8 +7086,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -8059,8 +8058,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.6.3",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,15 @@
 export type LilconfigResult = null | {
-	filepath: string;
 	config: any;
+	filepath: string;
 	isEmpty?: boolean;
 };
 interface OptionsBase {
 	cache?: boolean;
-	stopDir?: string;
-	searchPlaces?: string[];
 	ignoreEmptySearchPlaces?: boolean;
 	packageProp?: string | string[];
+	searchPlaces?: string[];
+	startDir?: string;
+	stopDir?: string;
 }
 export type Transform =
 	| TransformSync

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ module.exports.defaultLoaders = defaultLoaders;
 function getOptions(name, options, sync) {
 	/** @type {Required<import('./index').Options>} */
 	const conf = {
+	  startDir: process.cwd(),
 		stopDir: os.homedir(),
 		searchPlaces: getDefaultSearchPlaces(name, sync),
 		ignoreEmptySearchPlaces: true,
@@ -155,6 +156,7 @@ module.exports.lilconfig = function lilconfig(name, options) {
 		loaders,
 		packageProp,
 		searchPlaces,
+		startDir,
 		stopDir,
 		transform,
 		cache,
@@ -164,7 +166,7 @@ module.exports.lilconfig = function lilconfig(name, options) {
 	const emplace = makeEmplace(cache);
 
 	return {
-		async search(searchFrom = process.cwd()) {
+		async search(searchFrom = startDir) {
 			/** @type {import('./index').LilconfigResult} */
 			const result = {
 				config: null,


### PR DESCRIPTION
Adds a `startDir` option which allows specifying the point at which to start searching. Resolves #51. 