### PR TITLE
feat: Support Dynamic Import in Webpack Context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@biomejs/biome": "^1.6.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^14.18.63",
+        "@types/webpack-env": "^1.18.5",
         "cosmiconfig": "^8.3.6",
         "jest": "^29.7.0",
         "typescript": "^5.3.3",
@@ -1625,6 +1626,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.5.tgz",
+      "integrity": "sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6628,6 +6635,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "@types/webpack-env": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.5.tgz",
+      "integrity": "sha512-wz7kjjRRj8/Lty4B+Kr0LN6Ypc/3SymeCCGSbaXp2leH0ZVg/PriNiOwNj4bD4uphI7A8NXS4b6Gl373sfO5mA==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "^1.6.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^14.18.63",
+    "@types/webpack-env": "^1.18.5",
     "cosmiconfig": "^8.3.6",
     "jest": "^29.7.0",
     "typescript": "^5.3.3",

--- a/src/index.js
+++ b/src/index.js
@@ -39,11 +39,13 @@ function parentDir(p) {
 
 /** @type {import('./index').LoaderSync} */
 const jsonLoader = (_, content) => JSON.parse(content);
+// Use plain require in webpack context for dynamic import
+const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
 /** @type {import('./index').LoadersSync} */
 const defaultLoadersSync = Object.freeze({
-	'.js': require,
-	'.json': require,
-	'.cjs': require,
+	'.js': requireFunc,
+	'.json': requireFunc,
+	'.cjs': requireFunc,
 	noExt: jsonLoader,
 });
 module.exports.defaultLoadersSync = defaultLoadersSync;
@@ -56,7 +58,7 @@ const dynamicImport = async id => {
 		return mod.default;
 	} catch (e) {
 		try {
-			return require(id);
+			return requireFunc(id);
 		} catch (/** @type {any} */ requireE) {
 			if (
 				requireE.code === 'ERR_REQUIRE_ESM' ||

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ module.exports.defaultLoadersSync = defaultLoadersSync;
 /** @type {import('./index').Loader} */
 const dynamicImport = async id => {
 	try {
-		const mod = await import(id);
+		const mod = await import(/* webpackIgnore: true */ id);
 
 		return mod.default;
 	} catch (e) {


### PR DESCRIPTION
Credit: Thanks @jeremiegirault for proposing the changes in https://github.com/sindresorhus/import-fresh/issues/21

# Description
Webpack will try to bundle modules during compile time and replace the original `require`, so using `require` directly in the Webpack context to load configs could result in `MODULE_NOT_FOUND` error. Switching to `__non_webpack_require__` to use plain `require` while in the Webpack environment.

About `__non_webpack_require__`:
- [Webpack doc](https://webpack.js.org/api/module-variables/#__non_webpack_require__-webpack-specific)
- An explanation with more details: [StackOverflow](https://stackoverflow.com/a/46186322)

Try to solve issues like:
- https://github.com/vercel/next.js/issues/64802
- https://github.com/sindresorhus/import-fresh/issues/21

Making these changes will eventually make it possible to replace `cosmiconfig` with `lilconfig` in [`next-logger`](https://github.com/sainsburys-tech/next-logger)

# Test
`npm run test`