### PR TITLE
fix: force esm to reload the new module instead of the cached one

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ module.exports.defaultLoadersSync = defaultLoadersSync;
 /** @type {import('./index').Loader} */
 const dynamicImport = async id => {
 	try {
-		const mod = await import(/* webpackIgnore: true */ id);
+		const mod = await import(/* webpackIgnore: true */ `${id}?timestamp=${Date.now()}`);
 
 		return mod.default;
 	} catch (e) {


### PR DESCRIPTION
Without this change, config files stored as esm (the ones that use the dynamicImport loader) won't be updated. Esm returns the previous loaded state of the module.